### PR TITLE
add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "ruby_protobuf"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 vector-tile-spec reading for Ruby
 
 ## dependency
-- protobuf -- brew install protobuf
-- ruby_protobuf -- gem install ruby_protobuf
+- protobuf -- `brew install protobuf`
+- ruby_protobuf -- `bundle install` (with [Bundler](http://bundler.io/)) or `gem install ruby_protobuf` (without Bundler)
 
 ## example
 ```sh
+### install gems with bundler
+$ gem install bundler
+$ bundle install
+
+### execute mvt.rb
 $ ./mvt.rb https://globalmaps-vt.github.io/gmjp22vt/2/3/1.mvt
 layer lsBA010: 338 features, version 2, extent 4096
   keys: ["f_code", "acc", "exs", "soc"]

--- a/mvt.rb
+++ b/mvt.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 require 'open-uri'
+require 'bundler/setup'
 require './vector_tile.pb.rb'
 
 def process(url)


### PR DESCRIPTION
With this PR, you can install this tool with Bundler (without installing `ruby_protobuf` in global).

I guess the tool like this should be a Ruby gem and can be installed such as `gem install mvt`.  I hope this patch is a first step to do so.
